### PR TITLE
UDFPS: conditionally trigger onFingerDown with regular action down events

### DIFF
--- a/packages/SystemUI/res/values/banana_config.xml
+++ b/packages/SystemUI/res/values/banana_config.xml
@@ -115,4 +115,7 @@
 
     <!-- Body font family -->
     <string name="config_bodyFontFamily">@*android:string/config_bodyFontFamily</string>
+
+    <!-- Whether to call onFingerDown with regular action down events -->
+    <bool name="config_onFingerDownWithActionDown">true</bool>
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/biometrics/UdfpsController.java
+++ b/packages/SystemUI/src/com/android/systemui/biometrics/UdfpsController.java
@@ -630,6 +630,13 @@ public class UdfpsController implements DozeReceiver, Dumpable {
                     // data for many other pointers because of multi-touch support.
                     mActivePointerId = event.getPointerId(0);
                     mVelocityTracker.addMovement(event);
+                    if (shouldTriggerOnFingerDownWithActionDown()) {
+                        final int idx = mActivePointerId == -1
+                                ? event.getPointerId(0)
+                                : event.findPointerIndex(mActivePointerId);
+                        onFingerDown(requestId, (int) event.getRawX(), (int) event.getRawY(),
+                                (int) event.getTouchMinor(idx), (int) event.getTouchMajor(idx));
+                    }
                     handled = true;
                     mAcquiredReceived = false;
                 }
@@ -738,6 +745,11 @@ public class UdfpsController implements DozeReceiver, Dumpable {
                 // Do nothing.
         }
         return handled;
+    }
+
+    private boolean shouldTriggerOnFingerDownWithActionDown() {
+        return mContext.getResources().getBoolean(
+                R.bool.config_onFingerDownWithActionDown);
     }
 
     private boolean shouldTryToDismissKeyguard() {


### PR DESCRIPTION
Change 1aa9c6e69de5156daa463dfe068444822155629e is not good for all devices, so use an overlay to control whether
to trigger onFingerDown with regular action down events.

Signed-off-by: Matt Filetto <matt.filetto@gmail.com>