### PR TITLE
services: core: Temporaily handle NullPointerException in PackageMana…

### DIFF
--- a/services/core/java/com/android/server/pm/PackageManagerService.java
+++ b/services/core/java/com/android/server/pm/PackageManagerService.java
@@ -2455,15 +2455,21 @@ public class PackageManagerService implements PackageSender, TestUtilityService 
             if (!enable) {
                 mDisabledComponentsList.add(cn);
             }
-            Slog.v(TAG, "Changing enabled state of " + name + " to " + enable);
+            Slog.v(TAG, "Changing enabled state of " + name + " to [" + enable + "].");
             String className = cn.getClassName();
+            
             PackageSetting pkgSetting = mSettings.mPackages.get(cn.getPackageName());
-            AndroidPackage pkg = pkgSetting.getPkg();
-            if (pkgSetting == null || pkg == null
-                    || !AndroidPackageUtils.hasComponentClassName(pkg, className)) {
-                Slog.w(TAG, "Unable to change enabled state of " + name + " to " + enable);
+            if (pkgSetting == null) {
+                Slog.w(TAG, "Unable to change enabled state of " + name + " to [" + enable + "]. reason: PackageSetting is null.");
                 continue;
             }
+            
+            AndroidPackage pkg = pkgSetting.getPkg();
+            if (pkg == null || !AndroidPackageUtils.hasComponentClassName(pkg, className)) {
+                Slog.w(TAG, "Unable to change enabled state of " + name + " to [" + enable + "]. reason: AndroidPackage is null.");
+                continue;
+            }
+            
             if (enable) {
                 pkgSetting.enableComponentLPw(className, UserHandle.USER_OWNER);
             } else {


### PR DESCRIPTION
…gerService

Zygote crashing in several times and system doesn't boot properly in some devices. It seems pkgSetting gets null for some reason. So I did temporarily this fixing until find the cause.

Logcat:
02-23 07:32:26.863  1759  1759 E System  : ****************************************** 02-23 07:32:26.863  1759  1759 E System  : ************ Failure starting system services 02-23 07:32:26.863  1759  1759 E System  : java.lang.NullPointerException: Attempt to invoke virtual method 'com.android.server.pm.parsing.pkg.AndroidPackage com.android.server.pm.PackageSetting.getPkg()' on a null object reference 02-23 07:32:26.863  1759  1759 E System  : at com.android.server.pm.PackageManagerService.enableComponents(PackageManagerService.java:2295) 02-23 07:32:26.863  1759  1759 E System  : at com.android.server.pm.PackageManagerService.<init>(PackageManagerService.java:2093) 02-23 07:32:26.863  1759  1759 E System  : at com.android.server.pm.PackageManagerService.main(PackageManagerService.java:1497) 02-23 07:32:26.863  1759  1759 E System  : at com.android.server.SystemServer.startBootstrapServices(SystemServer.java:1245) 02-23 07:32:26.863  1759  1759 E System  : at com.android.server.SystemServer.run(SystemServer.java:949) 02-23 07:32:26.863  1759  1759 E System  : at com.android.server.SystemServer.main(SystemServer.java:661) 02-23 07:32:26.863  1759  1759 E System  : at java.lang.reflect.Method.invoke(Native Method) 02-23 07:32:26.863  1759  1759 E System  : at com.android.internal.os.RuntimeInit.run(RuntimeInit.java:548) 02-23 07:32:26.863  1759  1759 E System  : at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:920) 02-23 07:32:26.863  1759  1759 E Zygote  : System zygote died with fatal exception

Change-Id: I24245b7666bc243f4ba3cb4015c75a1c68043c64